### PR TITLE
Fix build on 32-bit.

### DIFF
--- a/selinux/src/context_restore/mod.rs
+++ b/selinux/src/context_restore/mod.rs
@@ -278,7 +278,7 @@ where
         }
 
         Ok(flags.contains(RestoreFlags::COUNT_ERRORS).then(|| unsafe {
-            (OptionalNativeFunctions::get().selinux_restorecon_get_skipped_errors)()
+            u64::from((OptionalNativeFunctions::get().selinux_restorecon_get_skipped_errors)())
         }))
     }
 


### PR DESCRIPTION
The build fails on 32-bit systems with.
 
    error[E0308]: mismatched types
        --> selinux/src/context_restore/mod.rs:280:12
         |
     280 |           Ok(flags.contains(RestoreFlags::COUNT_ERRORS).then(|| unsafe {
         |  ____________^
     281 | |             (OptionalNativeFunctions::get().selinux_restorecon_get_skipped_errors)()
     282 | |         }))
         | |__________^ expected `u64`, found `u32`
         |
         = note: expected enum `Option<u64>`
                    found enum `Option<u32>

This patch converts the u32 to an u64 using "from". This should be a no-op if it is already a u64.