### PR TITLE
Add license to selinux crate

### DIFF
--- a/selinux/LICENSE.txt
+++ b/selinux/LICENSE.txt
@@ -1,0 +1,1 @@
+../LICENSE.txt


### PR DESCRIPTION
The `Cargo.toml` for the `selinux` crate is in a subdirectory, while the `LICENSE.txt` is at the root of the repository, meaning when packaging the crate the license file does not get picked up.

Symlink it in so we are distributing the license file, which is enforced by Linux distributions such as Fedora

```
michel in selinux/selinux on  add-license [+] is 📦 v0.4.2 via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
warning: readme `../README.md` appears to be a path outside of the package, but there is already a file named `README.md` in the root of the package. The archived crate will contain the copy in the root of the package. Update the readme to point to the path relative to the root of the package to remove this warning.
   Packaging selinux v0.4.2 (/home/michel/src/github/koutheir/selinux/selinux)
    Packaged 22 files, 202.0KiB (36.2KiB compressed)

michel in selinux/selinux on  add-license [+] is 📦 v0.4.2 via 🦀 v1.73.0
⬢ [fedora-toolbox:38] ❯ tar tf ../target/package/selinux-0.4.2.crate | grep LICENSE
selinux-0.4.2/LICENSE.txt
```